### PR TITLE
feat: add x-nullable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ interface IValidatorConfig {
   // allow additional properties not defined in the Spec
   allowAdditionalProperties?: boolean;
 
+  // allow usage of x-nullable for properties, defaults to disallow
+  allowXNullable?: boolean;
+
   // HTTP and HTTPS are allowed by default
   disallowHttp?: boolean;
   disallowHttps?: boolean;
@@ -253,6 +256,20 @@ do that with the ignoreError function (see "Ignoring Errors" below), or you can 
 ```TypeScript
 let config: IValidatorConfig = {
     allowAdditionalProperties: true
+};
+```
+
+## Allowing `x-nullable` properties
+A common extension for Swagger 2 is `x-nullable`, based on
+[`nullable` from the OpenAPI 3 spec](https://swagger.io/specification/#schemaNullable).
+This allows a property to be returned as `null` instead of the intended type.
+
+By enabling this configuration, the `x-nullable` property is recognized and respected
+when validating types.
+
+```TypeScript
+let config: IValidatorConfig = {
+    allowXNullable: true
 };
 ```
 

--- a/lib/configuration-interfaces/validator-config.d.ts
+++ b/lib/configuration-interfaces/validator-config.d.ts
@@ -3,6 +3,7 @@ import { ITraceStep, IValidationError, ICustomValidationError } from '../result'
 export interface IValidatorConfig {
     partialsDir?: string;
     allowAdditionalProperties?: boolean;
+    allowXNullable?: boolean;
     disallowHttp?: boolean;
     disallowHttps?: boolean;
     customValidation?: (test: any, schema: Swagger.Schema, spec: Swagger.Spec, trace: Array<ITraceStep>, otherErrors: Array<ICustomValidationError>, resolve?: (validationErrors: ICustomValidationError[]) => void, reject?: (reason: string) => void) => ICustomValidationError[] | void | undefined;

--- a/lib/validators/GenericValidator.d.ts
+++ b/lib/validators/GenericValidator.d.ts
@@ -3,4 +3,7 @@ import * as Swagger from 'swagger-schema-official';
 import * as Promise from 'bluebird';
 import { IValidatorConfig } from '../configuration-interfaces/validator-config';
 import { ITraceStep, IValidationError } from '../result';
-export declare function validateType(test: any, schema: Swagger.Schema, spec: Swagger.Spec, config: IValidatorConfig, trace: Array<ITraceStep>): Promise<Array<IValidationError>>;
+export interface ISchemaWithNullable extends Swagger.Schema {
+    'x-nullable'?: boolean;
+}
+export declare function validateType(test: any, schema: ISchemaWithNullable, spec: Swagger.Spec, config: IValidatorConfig, trace: Array<ITraceStep>): Promise<Array<IValidationError>>;

--- a/lib/validators/GenericValidator.js
+++ b/lib/validators/GenericValidator.js
@@ -23,6 +23,9 @@ function validateType(test, schema, spec, config, trace) {
     if (typeShouldBe === 'integer') {
         typeShouldBe = 'number';
     }
+    if (config.allowXNullable === true && typeIs === 'null' && schema['x-nullable'] === true) {
+        typeShouldBe = 'null';
+    }
     if (typeIs !== typeShouldBe) {
         pushError_1.pushError({
             trace: trace,

--- a/lib/validators/ModelValidator.js
+++ b/lib/validators/ModelValidator.js
@@ -46,6 +46,8 @@ function validateModel(test, schema, spec, config, trace) {
                 case 'number':
                     validator = NumberValidator_1.validateNumber;
                     break;
+                case 'null':
+                    break;
                 case 'array':
                     validator = ArrayValidator_1.validateArray;
                     break;

--- a/lib/validators/ObjectValidator.d.ts
+++ b/lib/validators/ObjectValidator.d.ts
@@ -3,4 +3,7 @@ import * as Swagger from 'swagger-schema-official';
 import * as Promise from 'bluebird';
 import { IValidatorConfig } from '../configuration-interfaces/validator-config';
 import { ITraceStep, IValidationError } from '../result';
-export declare function validateObject(test: any, schema: Swagger.Schema, spec: Swagger.Spec, config: IValidatorConfig, trace: Array<ITraceStep>): Promise<Array<IValidationError>>;
+export interface ISchemaWithNullable extends Swagger.Schema {
+    'x-nullable'?: boolean;
+}
+export declare function validateObject(test: any, schema: ISchemaWithNullable, spec: Swagger.Spec, config: IValidatorConfig, trace: Array<ITraceStep>): Promise<Array<IValidationError>>;

--- a/lib/validators/ObjectValidator.js
+++ b/lib/validators/ObjectValidator.js
@@ -8,10 +8,16 @@ function validateObject(test, schema, spec, config, trace) {
     if (schema === undefined || spec === undefined) {
         throw new Error('Schema or spec is not defined');
     }
+    if (config.allowXNullable === true && test === null && schema['x-nullable'] === true) {
+        return Promise.resolve([]);
+    }
     if (!test || !(test instanceof Object)) {
         var typeIs = typeof (test);
         if (Array.isArray(test)) {
             typeIs = 'array';
+        }
+        if (test === null) {
+            typeIs = 'null';
         }
         var typeShouldBe = schema.title ? schema.title : 'object';
         return Promise.resolve([

--- a/src/configuration-interfaces/validator-config.ts
+++ b/src/configuration-interfaces/validator-config.ts
@@ -6,6 +6,7 @@ import { ITraceStep, IValidationError, ICustomValidationError} from '../result';
 export interface IValidatorConfig {
   partialsDir?: string;
   allowAdditionalProperties?: boolean;
+  allowXNullable?: boolean;
   disallowHttp?: boolean;
   disallowHttps?: boolean;
   customValidation?: (

--- a/src/validators/GenericValidator.ts
+++ b/src/validators/GenericValidator.ts
@@ -6,8 +6,12 @@ import { IValidatorConfig } from '../configuration-interfaces/validator-config';
 import { ITraceStep, IValidationError, ValidationErrorType } from '../result';
 import { pushError } from '../helpers/pushError';
 
+export interface ISchemaWithNullable extends Swagger.Schema {
+  'x-nullable'?: boolean;
+}
+
 // checks for simple type mismatches (numbers, strings, objects etc)
-export function validateType(test: any, schema: Swagger.Schema, spec: Swagger.Spec, config: IValidatorConfig, trace: Array<ITraceStep>): Promise<Array<IValidationError>> {
+export function validateType(test: any, schema: ISchemaWithNullable, spec: Swagger.Spec, config: IValidatorConfig, trace: Array<ITraceStep>): Promise<Array<IValidationError>> {
   let errors: Array<IValidationError> = [];
 
   let typeIs = getTypeName(test);
@@ -29,6 +33,10 @@ export function validateType(test: any, schema: Swagger.Schema, spec: Swagger.Sp
   // so replace integer with number
   if (typeShouldBe === 'integer') {
     typeShouldBe = 'number';
+  }
+
+  if (config.allowXNullable === true && typeIs === 'null' && schema['x-nullable'] === true) {
+    typeShouldBe = 'null';
   }
 
   if (typeIs !== typeShouldBe) {

--- a/src/validators/ModelValidator.ts
+++ b/src/validators/ModelValidator.ts
@@ -63,6 +63,8 @@ export function validateModel(test: any, schema: Swagger.Schema, spec: Swagger.S
           case 'number':
             validator = validateNumber;
             break;
+          case 'null':
+            break;
           case 'array':
             validator = validateArray;
             break;

--- a/src/validators/ObjectValidator.ts
+++ b/src/validators/ObjectValidator.ts
@@ -18,16 +18,26 @@ interface ISwaggerProperties {
   [propertyName: string]: Swagger.Schema;
 }
 
+export interface ISchemaWithNullable extends Swagger.Schema {
+  'x-nullable'?: boolean;
+}
 
-export function validateObject(test: any, schema: Swagger.Schema, spec: Swagger.Spec, config: IValidatorConfig, trace: Array<ITraceStep>): Promise<Array<IValidationError>> {
+export function validateObject(test: any, schema: ISchemaWithNullable, spec: Swagger.Spec, config: IValidatorConfig, trace: Array<ITraceStep>): Promise<Array<IValidationError>> {
   if (schema === undefined || spec === undefined) {
     throw new Error('Schema or spec is not defined');
+  }
+
+  if (config.allowXNullable === true && test === null && schema['x-nullable'] === true){
+    return Promise.resolve([]);
   }
 
   if (!test || !(test instanceof Object)) {
     let typeIs: string = typeof (test);
     if (Array.isArray(test)) {
       typeIs = 'array';
+    }
+    if (test === null) {
+      typeIs = 'null';
     }
 
     let typeShouldBe = schema.title ? schema.title : 'object';

--- a/test/generic-validator.spec.ts
+++ b/test/generic-validator.spec.ts
@@ -11,7 +11,6 @@ let dir = join(__dirname, 'specs', 'yaml');
 let yaml = join(dir, 'swagger.yaml');
 let validator = new Handler(yaml, {partialsDir: dir});
 
-
 describe('GenericValidator', () => {
   it('should invalidate string instead of number', (done) => {
     let pet = {
@@ -87,6 +86,52 @@ describe('GenericValidator', () => {
       expect(error.trace[0].stepName).to.equals('Pet');
       expect(error.trace[1].stepName).to.equals('happy');
       expect(error.typeIs).to.equals('string');
+      expect(error.typeShouldBe).to.equals('boolean');
+
+      done();
+    }).catch(err => done(new Error(err)));
+  });
+
+  it('should validate null with x-nullable', (done) => {
+    let validator = new Handler(yaml, {allowXNullable: true, partialsDir: dir});
+
+    let pet: {
+      id: number,
+      name: string,
+      nullable: string 
+    } = {
+      id: 123,
+      name: 'Doge',
+      nullable: null
+    };
+
+    validator.validateModel(pet, 'Pet').then(result => {
+      expect(result.errors).to.empty;
+
+      done();
+    }).catch(err => done(new Error(err)));
+  });
+
+  it('should invalidate null without x-nullable', (done) => {
+    let pet: {
+      id: number,
+      name: string,
+      happy: string 
+    } = {
+      id: 123,
+      name: 'Doge',
+      happy: null
+    };
+
+    validator.validateModel(pet, 'Pet').then(result => {
+      expect(result.errors).to.lengthOf(1);
+
+      let error: ITypeValidationError = result.errors[0];
+      expect(error.errorType).to.equals(ValidationErrorType.TYPE_MISMATCH);
+      expect(error.trace).to.length(2);
+      expect(error.trace[0].stepName).to.equals('Pet');
+      expect(error.trace[1].stepName).to.equals('happy');
+      expect(error.typeIs).to.equals('null');
       expect(error.typeShouldBe).to.equals('boolean');
 
       done();

--- a/test/object-validator_nullable.spec.ts
+++ b/test/object-validator_nullable.spec.ts
@@ -1,0 +1,61 @@
+import { Handler } from '../src/handler';
+import { ITypeValidationError, ValidationErrorType } from '../src/result';
+
+import * as chai from 'chai';
+const expect = chai.expect;
+
+import { join } from 'path';
+
+let dir = join(__dirname, 'specs', 'yaml');
+let yaml = join(dir, 'swagger.yaml');
+let validator = new Handler(yaml, {partialsDir: dir});
+
+describe('ObjectValidator', () => {
+  it('should invalidate a nullable object when null and option is disabled', (done) => {
+    let nullableRef: {
+      nullableRef: {
+        test: string
+      }
+    } = {
+      nullableRef: null
+    };
+
+    validator.validateModel(nullableRef, 'NullableRef').then(result => {
+      expect(result.errors).to.lengthOf(1);
+
+      let error: ITypeValidationError = result.errors[0];
+      expect(error.errorType).to.equals(ValidationErrorType.TYPE_MISMATCH);
+      expect(error.trace).to.length(2);
+      expect(error.trace[0].stepName).to.equals('NullableRef');
+      expect(error.trace[1].stepName).to.equals('nullableRef');
+      expect(error.typeIs).to.equals('null');
+      expect(error.typeShouldBe).to.equals('object');
+
+      done();
+    })
+    .catch(err => {
+      done(new Error(err));
+    });
+  });
+
+  it('should validate a nullable object when null', (done) => {
+    let validator = new Handler(yaml, {allowXNullable: true, partialsDir: dir});
+
+    let nullableRef: {
+      nullableRef: {
+        test: string
+      }
+    } = {
+      nullableRef: null
+    };
+
+    validator.validateModel(nullableRef, 'NullableRef').then(result => {
+      expect(result.errors).to.empty;
+
+      done();
+    })
+    .catch(err => {
+      done(new Error(err));
+    });
+  });
+});

--- a/test/specs/yaml/definitions/pet.yml
+++ b/test/specs/yaml/definitions/pet.yml
@@ -51,3 +51,6 @@ properties:
   email:
     type: string
     pattern: '/^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/'
+  nullable:
+    type: string
+    x-nullable: true

--- a/test/specs/yaml/swagger.yaml
+++ b/test/specs/yaml/swagger.yaml
@@ -1,4 +1,4 @@
-swagger: "2.0"
+swagger: '2.0'
 info:
   version: 1.0.0
   title: Some definitions to test a swagger model validator
@@ -28,6 +28,17 @@ definitions:
     type: array
     items:
       $ref: '#/definitions/Medium'
+
+  Nullable:
+    properties:
+      test:
+        type: string
+    x-nullable: true
+
+  NullableRef:
+    properties:
+      nullableRef:
+        $ref: '#/definitions/Nullable'
 
   Image:
     required:
@@ -89,5 +100,5 @@ paths:
   /:
     get:
       responses:
-        "200":
+        '200':
           description: Paths are not needed


### PR DESCRIPTION
OpenAPI 3 introduces [`nullable` as a valid schema option](https://swagger.io/specification/#schemaNullable), to allow for values that are returned from an API and explicitly defined as empty instead of their original type.

This is very useful, especially if the conversation is around actions such as "keep current value" (`undefined`, so no property sent), "erase current value" (`null`) or "replace with new value" (the original type).

Apiary has a very useful [Swagger vendor extensions document that details `x-nullable`](https://help.apiary.io/api_101/swagger-extensions/#x-nullable).

Closes #8.