### PR TITLE
Update js-yaml dependecy to 3.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.0",
-    "js-yaml": "3.7.0",
+    "js-yaml": "3.13.1",
     "@types/swagger-schema-official": "2.0.1",
     "@types/bluebird": "3.5.3"
   },


### PR DESCRIPTION
Updating js-yaml dependency due to vulnerabilities in older version. Please check npm audit results:

 Moderate        Denial of Service                                                                                                                          
 Package         js-yaml                                                                                                                                      
 Patched in      >=3.13.0                                                                                                                                      
 Dependency of   swagger-object-validator                                      
 Path            swagger-object-validator > js-yaml                            
 More info       https://nodesecurity.io/advisories/788                        
                                                                                                                                                              
  High            Code Injection                                                
  Package         js-yaml                                                                                                                                       
  Patched in      >=3.13.1                                                      
  Dependency of   swagger-object-validator                                      
  Path            swagger-object-validator > js-yaml                            
  More info       https://nodesecurity.io/advisories/813